### PR TITLE
Fix #1060: Remove global random seed from tests

### DIFF
--- a/src/openfermion/circuits/gates/fermionic_simulation_test.py
+++ b/src/openfermion/circuits/gates/fermionic_simulation_test.py
@@ -53,7 +53,7 @@ def test_state_swap_eigen_component(index_pair, n_qubits):
         assert np.allclose(actual_component, expected_component)
 
 
-@pytest.mark.parametrize('n_modes, seed', [(7, np.random.randint(1 << 30)) for _ in range(2)])
+@pytest.mark.parametrize('n_modes, seed', [(7, 84392), (7, 129302)])
 def test_interaction_operator_interconversion(n_modes, seed):
     operator = openfermion.random_interaction_operator(n_modes, real=False, seed=seed)
     gates = openfermion.fermionic_simulation_gates_from_interaction_operator(operator)
@@ -222,7 +222,7 @@ def test_fermionic_simulation_gate(gate):
     assert gate.num_weights() == super(type(gate), gate).num_weights()
 
 
-@pytest.mark.parametrize('weights', list(np.random.rand(10, 3)) + [(1, 0, 1)])
+@pytest.mark.parametrize('weights', [(0.1, 0.5, 0.9), (0.2, 0.4, 0.8), (0.7, 0.3, 0.1), (0.1, 0.1, 0.1), (0.5, 0.5, 0.5), (0.8, 0.2, 0.9), (0.3, 0.6, 0.4), (0.9, 0.8, 0.7), (0.4, 0.7, 0.2), (0.6, 0.9, 0.3)] + [(1, 0, 1)])
 def test_weights_and_exponent(weights):
     exponents = np.linspace(-1, 1, 8)
     gates = tuple(
@@ -263,8 +263,8 @@ def test_zero_weights():
     'weights,exponent',
     [
         (
-            (np.random.uniform(-5, 5) + 1j * np.random.uniform(-5, 5), np.random.uniform(-5, 5)),
-            np.random.uniform(-5, 5),
+            (1.2 + 3.4j, 2.1),
+            -1.5,
         )
         for _ in range(5)
     ],
@@ -342,8 +342,11 @@ def test_cubic_fermionic_simulation_gate_consistency_special(exponent, control):
 @pytest.mark.parametrize(
     'weights,exponent',
     [
-        (np.random.uniform(-5, 5, 3) + 1j * np.random.uniform(-5, 5, 3), np.random.uniform(-5, 5))
-        for _ in range(5)
+        (np.array([-2.1+1.3j, 0.4-3.5j, 4.2+2.8j]), -1.2),
+        (np.array([3.1-0.9j, -4.5+1.1j, 2.0-2.0j]), 3.4),
+        (np.array([-0.5+4.9j, 1.2+0.1j, -3.3-4.4j]), 0.8),
+        (np.array([4.8-2.2j, -1.1-1.1j, 0.5+3.7j]), -4.1),
+        (np.array([-3.9+0.8j, 2.7-2.6j, -0.2+4.5j]), 2.3),
     ],
 )
 def test_cubic_fermionic_simulation_gate_consistency_docstring(weights, exponent):
@@ -598,7 +601,7 @@ test_weights = [1.0, 0.5, 0.25, 0.1, 0.0, -0.5]
 
 
 @pytest.mark.parametrize(
-    'weights', itertools.chain(itertools.product(test_weights, repeat=3), np.random.rand(10, 3))
+    'weights', itertools.chain(itertools.product(test_weights, repeat=3), [(0.1, 0.5, 0.9), (0.2, 0.4, 0.8), (0.7, 0.3, 0.1), (0.1, 0.1, 0.1), (0.5, 0.5, 0.5), (0.8, 0.2, 0.9), (0.3, 0.6, 0.4), (0.9, 0.8, 0.7), (0.4, 0.7, 0.2), (0.6, 0.9, 0.3)])
 )
 def test_quartic_fermionic_simulation_decompose(weights):
     cirq.testing.assert_decompose_is_consistent_with_unitary(
@@ -609,8 +612,11 @@ def test_quartic_fermionic_simulation_decompose(weights):
 @pytest.mark.parametrize(
     'weights,exponent',
     [
-        (np.random.uniform(-5, 5, 3) + 1j * np.random.uniform(-5, 5, 3), np.random.uniform(-5, 5))
-        for _ in range(5)
+        (np.array([-2.1+1.3j, 0.4-3.5j, 4.2+2.8j]), -1.2),
+        (np.array([3.1-0.9j, -4.5+1.1j, 2.0-2.0j]), 3.4),
+        (np.array([-0.5+4.9j, 1.2+0.1j, -3.3-4.4j]), 0.8),
+        (np.array([4.8-2.2j, -1.1-1.1j, 0.5+3.7j]), -4.1),
+        (np.array([-3.9+0.8j, 2.7-2.6j, -0.2+4.5j]), 2.3),
     ],
 )
 def test_quartic_fermionic_simulation_unitary(weights, exponent):
@@ -679,8 +685,11 @@ def test_quartic_fermionic_simulation_gate_text_diagram():
 @pytest.mark.parametrize(
     'weights,exponent',
     [
-        (np.random.uniform(-5, 5, 3) + 1j * np.random.uniform(-5, 5, 3), np.random.uniform(-5, 5))
-        for _ in range(5)
+        (np.array([-2.1+1.3j, 0.4-3.5j, 4.2+2.8j]), -1.2),
+        (np.array([3.1-0.9j, -4.5+1.1j, 2.0-2.0j]), 3.4),
+        (np.array([-0.5+4.9j, 1.2+0.1j, -3.3-4.4j]), 0.8),
+        (np.array([4.8-2.2j, -1.1-1.1j, 0.5+3.7j]), -4.1),
+        (np.array([-3.9+0.8j, 2.7-2.6j, -0.2+4.5j]), 2.3),
     ],
 )
 def test_quartic_fermionic_simulation_apply_unitary(weights, exponent):

--- a/src/openfermion/conftest.py
+++ b/src/openfermion/conftest.py
@@ -21,8 +21,3 @@ def pytest_configure(config):
     os.environ['CIRQ_TESTING'] = "true"
 
 
-@pytest.fixture(autouse=True)
-def set_random_seed():
-    """Set a fixed random seed when testing."""
-    random.seed(0)
-    np.random.seed(0)

--- a/src/openfermion/hamiltonians/general_hubbard_test.py
+++ b/src/openfermion/hamiltonians/general_hubbard_test.py
@@ -51,12 +51,12 @@ def fermi_hubbard_from_general(
     itertools.product(
         range(1, 4),
         range(1, 4),
-        (random.uniform(0, 2.0),),
-        (random.uniform(0, 2.0),),
-        (random.uniform(0, 2.0),),
+        (1.3,),
+        (0.8,),
+        (1.9,),
         (True, False),
         (True, False),
-        (random.uniform(-1, 1),),
+        (-0.5,),
     ),
 )
 def test_fermi_hubbard_square_special_general_equivalence(
@@ -165,19 +165,17 @@ lattices = [
 
 
 @pytest.mark.parametrize(
-    'lattice,parameters,distinguish_edges',
+    'lattice,distinguish_edges,seed',
     [
-        (
-            lattice,
-            random_parameters(lattice, distinguish_edges=distinguish_edges),
-            distinguish_edges,
-        )
+        (lattice, distinguish_edges, seed)
         for lattice in lattices
-        for _ in range(2)
+        for seed in (123, 456)
         for distinguish_edges in (True, False)
     ],
 )
-def test_fermi_hubbard_square_lattice_random_parameters(lattice, parameters, distinguish_edges):
+def test_fermi_hubbard_square_lattice_random_parameters(lattice, distinguish_edges, seed):
+    random.seed(seed)
+    parameters = random_parameters(lattice, distinguish_edges=distinguish_edges)
     model = FermiHubbardModel(lattice, **parameters)
     hamiltonian = model.hamiltonian()
     terms_per_parameter = defaultdict(int)

--- a/src/openfermion/testing/random_test.py
+++ b/src/openfermion/testing/random_test.py
@@ -21,7 +21,7 @@ from openfermion.testing import random_interaction_operator_term
 
 @pytest.mark.parametrize(
     'order,real,seed',
-    [(k, r, random.randrange(2 << 30)) for k in [1, 2, 3, 4, 5] for r in [0, 1] for _ in range(5)],
+    [(k, r, seed_val) for k in [1, 2, 3, 4, 5] for r in [0, 1] for seed_val in [413, 892, 123, 999, 500]],
 )
 def test_random_interaction_operator_term(order, real, seed):
     op = random_interaction_operator_term(order, real, seed)

--- a/src/openfermion/utils/lattice_test.py
+++ b/src/openfermion/utils/lattice_test.py
@@ -26,8 +26,8 @@ def test_spin():
 @pytest.mark.parametrize(
     "x_dimension,y_dimension,n_dofs,spinless,periodic",
     itertools.product(
-        random.sample(range(3, 10), 3),
-        random.sample(range(3, 10), 3),
+        [3, 6, 9],
+        [4, 5, 8],
         range(1, 4),
         (False, True),
         (False, True),
@@ -123,7 +123,7 @@ def test_hubbard_square_lattice_edge_types():
         lattice.site_pairs_iter('banana')
 
 
-@pytest.mark.parametrize('d', random.sample(range(3, 10), 3))
+@pytest.mark.parametrize('d', [3, 6, 8])
 def test_hubbard_square_lattice_1xd(d):
     for shape, periodic in itertools.product(((1, d), (d, 1)), (True, False)):
         lattice = HubbardSquareLattice(*shape, periodic=periodic)
@@ -145,7 +145,7 @@ def test_hubbard_square_lattice_1xd(d):
         )
 
 
-@pytest.mark.parametrize('x,y', (random.sample(range(3, 10), 2) for _ in range(3)))
+@pytest.mark.parametrize('x,y', [(4, 7), (5, 9), (8, 3)])
 def test_hubbard_square_lattice_neighbors(x, y):
     for periodic in (True, False):
         lattice = HubbardSquareLattice(x, y, periodic=periodic)
@@ -157,7 +157,7 @@ def test_hubbard_square_lattice_neighbors(x, y):
         assert len(tuple(lattice.diagonal_neighbors_iter())) == n_diagonal_neighbors
 
 
-@pytest.mark.parametrize('d', random.sample(range(3, 10), 3))
+@pytest.mark.parametrize('d', [4, 7, 9])
 def test_hubbard_square_lattice_2xd(d):
     for shape, periodic in itertools.product(((2, d), (d, 2)), (True, False)):
         lattice = HubbardSquareLattice(*shape, periodic=periodic)
@@ -190,13 +190,26 @@ def test_hubbard_square_lattice_2x2():
     'kwargs',
     [
         {
-            'x_dimension': random.randrange(1, 10),
-            'y_dimension': random.randrange(1, 10),
-            'n_dofs': random.randrange(1, 10),
-            'spinless': random.choice((True, False)),
-            'periodic': random.choice((True, False)),
-        }
-        for _ in range(5)
+            'x_dimension': 4,
+            'y_dimension': 7,
+            'n_dofs': 2,
+            'spinless': False,
+            'periodic': True,
+        },
+        {
+            'x_dimension': 3,
+            'y_dimension': 3,
+            'n_dofs': 1,
+            'spinless': True,
+            'periodic': False,
+        },
+        {
+            'x_dimension': 5,
+            'y_dimension': 2,
+            'n_dofs': 3,
+            'spinless': True,
+            'periodic': True,
+        },
     ],
 )
 def test_hubbard_square_lattice_repr(kwargs):


### PR DESCRIPTION
Removed the global seed from conftest and fixed the randomly parametrized inputs.

---
*PR created automatically by Jules for task [6998816404824291497](https://jules.google.com/task/6998816404824291497) started by @mhucka*