### PR TITLE
Refactor: Remove Python 2 compatibility shims

### DIFF
--- a/src/openfermion/chem/molecular_data.py
+++ b/src/openfermion/chem/molecular_data.py
@@ -31,13 +31,6 @@ r"""NOTE ON PQRS CONVENTION:
     + 0.5 * \sum_{p,q,r,s} h[p,q,r,s] a_p^\dagger a_q^\dagger a_r a_s
 """
 
-# Define a compatible basestring for checking between Python 2 and 3
-try:
-    basestring
-except NameError:  # pragma: no cover
-    basestring = str
-
-
 # Define error objects which inherit from Exception.
 class MoleculeNameError(Exception):
     pass
@@ -248,7 +241,7 @@ def name_molecule(geometry, basis, multiplicity, charge, description):
     Raises:
         MoleculeNameError: If spin multiplicity is not valid.
     """
-    if not isinstance(geometry, basestring):
+    if not isinstance(geometry, str):
         # Get sorted atom vector.
         atoms = [item[0] for item in geometry]
         atom_charge_info = [(atom, atoms.count(atom)) for atom in set(atoms)]
@@ -501,7 +494,7 @@ class MolecularData(object):
 
         # Metadata fields with default values.
         self.charge = charge
-        if not isinstance(description, basestring):
+        if not isinstance(description, str):
             raise TypeError("description must be a string.")
         self.description = description
 
@@ -518,7 +511,7 @@ class MolecularData(object):
                 self.filename = data_directory + '/' + self.name
 
         # Attributes generated automatically by class.
-        if not isinstance(geometry, basestring):
+        if not isinstance(geometry, str):
             self.n_atoms = len(geometry)
             self.atoms = sorted(
                 [row[0] for row in geometry], key=lambda atom: periodic_hash_table[atom]
@@ -707,7 +700,7 @@ class MolecularData(object):
         with h5py.File("{}.hdf5".format(tmp_name), "w") as f:
             # Save geometry (atoms and positions need to be separate):
             d_geom = f.create_group("geometry")
-            if not isinstance(self.geometry, basestring):
+            if not isinstance(self.geometry, str):
                 atoms = [numpy.bytes_(item[0]) for item in self.geometry]
                 positions = numpy.array([list(item[1]) for item in self.geometry])
             else:

--- a/src/openfermion/testing/testing_utils.py
+++ b/src/openfermion/testing/testing_utils.py
@@ -338,17 +338,9 @@ def module_importable(module):
         bool
 
     """
-    import sys
+    from importlib import util
 
-    if sys.version_info >= (3, 4):
-        from importlib import util
-
-        plug_spec = util.find_spec(module)
-    else:
-        # Won't enter unless Python<3.4, so ignore for testing
-        import pkgutil  # pragma: ignore
-
-        plug_spec = pkgutil.find_loader(module)  # pragma: no cover
+    plug_spec = util.find_spec(module)
     if plug_spec is None:
         return False
     else:


### PR DESCRIPTION
This submission cleans up legacy Python 2 compatibility code. Since Python 3 is the only supported version now, these shims are no longer necessary.

Changes:
1. Replaced `basestring` shim with built-in `str` in `molecular_data.py`.
2. Removed older Python 3 version check for testing utility `module_importable` in `testing_utils.py`, relying solely on `importlib.util`.

---
*PR created automatically by Jules for task [11161586871802087205](https://jules.google.com/task/11161586871802087205) started by @mhucka*